### PR TITLE
fix: if pass is not present, ignore user, nick command

### DIFF
--- a/Source/Command/Nick.cpp
+++ b/Source/Command/Nick.cpp
@@ -32,7 +32,9 @@ bool Nick::isValidNickname(const std::string& nickname) const
 void Nick::execute(Resource& resource, Message message) {
 	Client*	client = resource.findClient(message.getClientFd());
 
-	if (message.getParam().size() < 2) {
+	if (!client->getPassed()) {
+		return ;
+	} else if (message.getParam().size() < 2) {
 		reply.errNoNicknameGiven(client);
 		return ;
 	} else if (resource.findClient(message.getParam()[1]) != NULL) {

--- a/Source/Command/User.cpp
+++ b/Source/Command/User.cpp
@@ -8,7 +8,9 @@ User::~User() { }
 void User::execute(Resource& resource, Message message) {
 	Client*	client = resource.findClient(message.getClientFd());
 	
-	if (message.getParam().size() < 5) {
+	if (!client->getPassed()) {
+		return ;
+	} else if (message.getParam().size() < 5) {
 		reply.errNeedMoreParams(client, message.getFirstParam());
 		return ;
 	} else if (client->getRegistered()) {


### PR DESCRIPTION
PASS 명령어가 들어오지 않았을 때 NICK, USER 커맨드 무시